### PR TITLE
Add basic StatusPage

### DIFF
--- a/src/main/kotlin/io/github/mmarco94/compose/adw/components/StatusPage.kt
+++ b/src/main/kotlin/io/github/mmarco94/compose/adw/components/StatusPage.kt
@@ -1,0 +1,42 @@
+package io.github.mmarco94.compose.adw.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposeNode
+import io.github.mmarco94.compose.GtkApplier
+import io.github.mmarco94.compose.GtkComposeNode
+import io.github.mmarco94.compose.SingleChildComposeNode
+import io.github.mmarco94.compose.gtk.components.Image
+import io.github.mmarco94.compose.modifier.Modifier
+import org.gnome.adw.SpinnerPaintable
+import org.gnome.adw.StatusPage
+
+@Composable
+fun StatusPage(
+    modifier: Modifier = Modifier,
+    title: String,
+    description: String? = null,
+    iconName: String? = null,
+    paintable: Image.Paintable? = null,
+    content: @Composable () -> Unit = {},
+) {
+    ComposeNode<GtkComposeNode<StatusPage>, GtkApplier>(
+        factory = {
+            SingleChildComposeNode(
+                StatusPage.builder().build(),
+                set = { child = it },
+            )
+        },
+        update = {
+            set(modifier) { applyModifier(it) }
+            set(title) { this.gObject.title = it }
+            set(description) { this.gObject.description = it }
+            set(iconName) { this.gObject.iconName = it }
+            set(paintable) {
+                (it?.paintable as? SpinnerPaintable)
+                    ?.let { spinnerPaintable -> spinnerPaintable.widget = this.gObject }
+                this.gObject.paintable = it?.paintable
+            }
+        },
+        content = content,
+    )
+}

--- a/src/test/kotlin/StatusPage.kt
+++ b/src/test/kotlin/StatusPage.kt
@@ -1,0 +1,50 @@
+import androidx.compose.runtime.*
+import io.github.mmarco94.compose.adw.application
+import io.github.mmarco94.compose.adw.components.ApplicationWindow
+import io.github.mmarco94.compose.adw.components.HeaderBar
+import io.github.mmarco94.compose.adw.components.StatusPage
+import io.github.mmarco94.compose.gtk.components.Image
+import io.github.mmarco94.compose.gtk.components.VerticalBox
+import io.github.mmarco94.compose.modifier.Modifier
+import io.github.mmarco94.compose.modifier.cssClasses
+import io.github.mmarco94.compose.modifier.expandVertically
+import org.gnome.adw.SpinnerPaintable
+
+fun main(args: Array<String>) {
+    application("my.example.HelloApp", args) {
+        ApplicationWindow(
+            application,
+            "StatusPage",
+            onClose = ::exitApplication,
+            defaultWidth = 800,
+            defaultHeight = 900,
+        ) {
+            val spinner: Image.Paintable? by remember { mutableStateOf(Image.Paintable(SpinnerPaintable.builder().build())) }
+
+            VerticalBox {
+                HeaderBar()
+                StatusPage(
+                    title = "Loading",
+                    description = "Please wait...",
+                    paintable = spinner,
+                    modifier = Modifier.expandVertically(),
+                )
+                StatusPage(
+                    title = "No Results Found",
+                    description = "Try a different search",
+                    iconName = "system-search-symbolic",
+                    modifier = Modifier
+                        .expandVertically()
+                        .cssClasses("compact"),
+                )
+                StatusPage(
+                    title = "No Results Found",
+                    description = "Try a different search",
+                    iconName = "system-search-symbolic",
+                    modifier = Modifier
+                        .expandVertically(),
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
I know the project is a proof of concept, but I do like it **a lot**, being fluent in Compose and keen on developing Gnome apps. So this POC -as incomplete as it is- looks awesome to me :+1: 

For some app prototype, I needed *Adwaita's StatusPage* component, so I added a basic compose version of it, in its simplest form. It's not much, but it's something.

If the project is not open for PRs yet, sorry about that and feel free to throw it away shamelessly :sweat_smile: 

![Capture d’écran du 2025-04-11 07-37-44](https://github.com/user-attachments/assets/ec1c0ac9-7154-434d-8b1b-572773dcc501)