### PR TITLE
Add LocalApplication composition local

### DIFF
--- a/src/main/kotlin/io/github/mmarco94/compose/Application.kt
+++ b/src/main/kotlin/io/github/mmarco94/compose/Application.kt
@@ -1,13 +1,6 @@
 package io.github.mmarco94.compose
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Composition
-import androidx.compose.runtime.MonotonicFrameClock
-import androidx.compose.runtime.Recomposer
-import androidx.compose.runtime.Stable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.runtime.snapshots.Snapshot
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
@@ -48,6 +41,8 @@ interface ApplicationScope {
     fun exitApplication()
 }
 
+val LocalApplication = staticCompositionLocalOf<Application> { throw RuntimeException("not in a GTK application") }
+
 fun Application.initializeApplication(
     args: Array<String>,
     content: @Composable ApplicationScope.() -> Unit,
@@ -77,7 +72,9 @@ fun Application.initializeApplication(
                 GtkDispatcher.active = true
                 composition.setContent {
                     if (isOpen) {
-                        appScope.content()
+                        CompositionLocalProvider(LocalApplication provides app) {
+                            appScope.content()
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/io/github/mmarco94/compose/adw/components/ApplicationWindow.kt
+++ b/src/main/kotlin/io/github/mmarco94/compose/adw/components/ApplicationWindow.kt
@@ -7,7 +7,6 @@ import io.github.mmarco94.compose.shared.components.initializeApplicationWindow
 import org.gnome.adw.ApplicationWindow
 import org.gnome.adw.Breakpoint
 import org.gnome.adw.BreakpointCondition
-import org.gnome.gtk.Application
 import org.gnome.gtk.CssProvider
 
 interface ApplicationWindowScope {
@@ -68,7 +67,6 @@ private class ApplicationWindowScopeImpl : ApplicationWindowScope {
 
 @Composable
 fun ApplicationWindow(
-    application: Application,
     title: String?,
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
@@ -90,7 +88,6 @@ fun ApplicationWindow(
             ApplicationWindow.builder()
         },
         modifier = modifier,
-        application = application,
         title = title,
         styles = styles,
         deletable = deletable,

--- a/src/main/kotlin/io/github/mmarco94/compose/gtk/components/ApplicationWindow.kt
+++ b/src/main/kotlin/io/github/mmarco94/compose/gtk/components/ApplicationWindow.kt
@@ -3,13 +3,11 @@ package io.github.mmarco94.compose.gtk.components
 import androidx.compose.runtime.Composable
 import io.github.mmarco94.compose.modifier.Modifier
 import io.github.mmarco94.compose.shared.components.initializeApplicationWindow
-import org.gnome.gtk.Application
 import org.gnome.gtk.ApplicationWindow
 import org.gnome.gtk.CssProvider
 
 @Composable
 fun ApplicationWindow(
-    application: Application,
     modifier: Modifier = Modifier,
     title: String?,
     onClose: () -> Unit,
@@ -30,7 +28,6 @@ fun ApplicationWindow(
             ApplicationWindow.builder()
         },
         modifier = modifier,
-        application = application,
         title = title,
         styles = styles,
         deletable = deletable,

--- a/src/main/kotlin/io/github/mmarco94/compose/shared/components/ApplicationWindow.kt
+++ b/src/main/kotlin/io/github/mmarco94/compose/shared/components/ApplicationWindow.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Updater
 import io.github.jwharm.javagi.gobject.SignalConnection
 import io.github.mmarco94.compose.GtkApplier
 import io.github.mmarco94.compose.GtkComposeNode
+import io.github.mmarco94.compose.LocalApplication
 import io.github.mmarco94.compose.SingleChildComposeNode
 import io.github.mmarco94.compose.modifier.Modifier
 import org.gnome.gtk.ApplicationWindow
@@ -40,7 +41,6 @@ private class GtkApplicationWindowComposeNode<AW : ApplicationWindow>(
 @Composable
 fun <AW : ApplicationWindow, B : ApplicationWindow.Builder<*>> initializeApplicationWindow(
     builder: () -> B,
-    application: org.gnome.gtk.Application,
     modifier: Modifier = Modifier,
     title: String?,
     onClose: () -> Unit,
@@ -58,17 +58,18 @@ fun <AW : ApplicationWindow, B : ApplicationWindow.Builder<*>> initializeApplica
     update: @DisallowComposableCalls Updater<out GtkComposeNode<AW>>.() -> Unit = {},
     content: @Composable () -> Unit,
 ) {
+    val application = LocalApplication.current
     ComposeNode<GtkApplicationWindowComposeNode<AW>, GtkApplier>(
         factory = {
             val window = builder()
                 .setFullscreened(fullscreen)
                 .build() as AW
             window.init()
+            window.application = application
             GtkApplicationWindowComposeNode(window, setContent)
         },
         update = {
             set(modifier) { applyModifier(it) }
-            set(application) { this.gObject.application = it }
             set(title) { this.gObject.title = it }
             set(onClose) {
                 this.onClose?.disconnect()

--- a/src/test/kotlin/Buttons.kt
+++ b/src/test/kotlin/Buttons.kt
@@ -7,7 +7,7 @@ import org.gnome.gtk.Orientation
 
 fun main(args: Array<String>) {
     application("my.example.HelloApp", args) {
-        ApplicationWindow(application, "Test", onClose = ::exitApplication) {
+        ApplicationWindow( "Test", onClose = ::exitApplication) {
             Box(orientation = Orientation.VERTICAL) {
                 HeaderBar()
 

--- a/src/test/kotlin/FancyWindow.kt
+++ b/src/test/kotlin/FancyWindow.kt
@@ -10,7 +10,7 @@ import org.gnome.gtk.PackType
 
 fun main(args: Array<String>) {
     application("my.example.HelloApp", args) {
-        ApplicationWindow(application, "Test", onClose = ::exitApplication, defaultWidth = 800) {
+        ApplicationWindow("Test", onClose = ::exitApplication, defaultWidth = 800) {
             VerticalBox {
                 Overlay(
                     mainChild = {

--- a/src/test/kotlin/Overlay.kt
+++ b/src/test/kotlin/Overlay.kt
@@ -15,7 +15,6 @@ private val BREAKPOINT_CONDITION = BreakpointCondition.parse("min-width: 800px")
 fun main(args: Array<String>) {
     application("my.example.HelloApp", args) {
         ApplicationWindow(
-            application,
             "Overlay",
             onClose = ::exitApplication,
             defaultWidth = 800,

--- a/src/test/kotlin/StatusPage.kt
+++ b/src/test/kotlin/StatusPage.kt
@@ -13,7 +13,6 @@ import org.gnome.adw.SpinnerPaintable
 fun main(args: Array<String>) {
     application("my.example.HelloApp", args) {
         ApplicationWindow(
-            application,
             "StatusPage",
             onClose = ::exitApplication,
             defaultWidth = 800,

--- a/src/test/kotlin/Tags.kt
+++ b/src/test/kotlin/Tags.kt
@@ -14,7 +14,7 @@ import org.gnome.adw.Toast
 
 fun main(args: Array<String>) {
     application("my.example.HelloApp", args) {
-        ApplicationWindow(application, "Test", onClose = ::exitApplication) {
+        ApplicationWindow("Test", onClose = ::exitApplication) {
             ToastOverlay {
                 VerticalBox {
                     HeaderBar()

--- a/src/test/kotlin/Toggle.kt
+++ b/src/test/kotlin/Toggle.kt
@@ -12,7 +12,7 @@ import org.gnome.gtk.Orientation
 
 fun main(args: Array<String>) {
     application("my.example.HelloApp", args) {
-        ApplicationWindow(application, "Test", onClose = ::exitApplication) {
+        ApplicationWindow("Test", onClose = ::exitApplication) {
             Box(orientation = Orientation.VERTICAL) {
                 HeaderBar()
 

--- a/src/test/kotlin/Uppercase.kt
+++ b/src/test/kotlin/Uppercase.kt
@@ -10,7 +10,7 @@ import org.gnome.gtk.Orientation
 
 fun main(args: Array<String>) {
     application("my.example.HelloApp", args) {
-        ApplicationWindow(application, "Test", onClose = ::exitApplication) {
+        ApplicationWindow("Test", onClose = ::exitApplication) {
             Box(orientation = Orientation.VERTICAL) {
                 HeaderBar()
 


### PR DESCRIPTION
In this PR, I provide access to the GTK application via a [composition local](https://developer.android.com/develop/ui/compose/compositionlocal).

This allows to make the application available throughout the composables hierarchy as `LocalApplication.current`, thus:
* making it possible to simplify a bit the current ApplicationWindow implementations (which is included in this PR)
* making it possible for future developments to access the application when needed without having to resort to inversion of control (this can be useful, for instance, to setup actions / accels, or to access the active window)

Plus it makes sense to give global access to our root object, in the same way the Android compose API gives access to the context via `LocalContext.current`.