### PR TITLE
Add adw Dialog component

### DIFF
--- a/src/main/kotlin/io/github/mmarco94/compose/GtkComposeNode.kt
+++ b/src/main/kotlin/io/github/mmarco94/compose/GtkComposeNode.kt
@@ -1,6 +1,7 @@
 package io.github.mmarco94.compose
 
 import io.github.mmarco94.compose.modifier.Modifier
+import org.gnome.adw.Dialog
 import org.gnome.gobject.GObject
 import org.gnome.gtk.Widget
 
@@ -33,7 +34,10 @@ internal open class SingleChildComposeNode<G : Widget>(
     private val stack = mutableListOf<Widget>()
 
     private fun recompute() {
-        gObject.set(stack.lastOrNull())
+        val widget = stack.lastOrNull()
+        if (widget.requiresAddToParent) {
+            gObject.set(widget)
+        }
     }
 
     override fun add(index: Int, child: GtkComposeNode<GObject>) {
@@ -145,3 +149,5 @@ internal abstract class GtkContainerComposeNode<G : GObject, C : GObject>(gObjec
     }
 }
 
+val Widget?.requiresAddToParent
+    get() = this !is Dialog

--- a/src/main/kotlin/io/github/mmarco94/compose/adw/components/Dialog.kt
+++ b/src/main/kotlin/io/github/mmarco94/compose/adw/components/Dialog.kt
@@ -1,0 +1,175 @@
+package io.github.mmarco94.compose.adw.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposeNode
+import androidx.compose.runtime.Updater
+import io.github.mmarco94.compose.GtkApplier
+import io.github.mmarco94.compose.GtkComposeNode
+import io.github.mmarco94.compose.SingleChildComposeNode
+import io.github.mmarco94.compose.modifier.Modifier
+import io.github.mmarco94.compose.shared.components.LocalApplicationWindow
+import org.gnome.adw.AboutDialog
+import org.gnome.adw.Dialog
+import org.gnome.adw.DialogPresentationMode
+import org.gnome.gtk.License
+
+/**
+ * TODO:
+ *   default widget
+ *   focus widget
+ *   current breakpoint
+ */
+@Composable
+private fun <D : GtkComposeNode<Dialog>> BaseDialog(
+    modifier: Modifier = Modifier,
+    canClose: Boolean = true,
+    contentHeight: Int = 0,
+    contentWidth: Int = 0,
+    isPresented: Boolean,
+    followsContentSize: Boolean = false,
+    presentationMode: DialogPresentationMode = DialogPresentationMode.AUTO,
+    title: String?,
+    onClose: () -> Unit = {},
+    content: @Composable () -> Unit = {},
+    creator: () -> D,
+    updater: Updater<D>.() -> Unit,
+) {
+    val applicationWindow = LocalApplicationWindow.current
+
+    ComposeNode<D, GtkApplier>(
+        factory = creator,
+        update = {
+            set(modifier) { applyModifier(it) }
+            set(title) { this.gObject.title = it }
+            set(presentationMode) { this.gObject.presentationMode = it }
+            set(canClose) { this.gObject.canClose = it }
+            set(followsContentSize) { this.gObject.followsContentSize = followsContentSize }
+            set(contentWidth) { this.gObject.contentWidth = contentWidth }
+            set(contentHeight) { this.gObject.contentHeight = contentHeight }
+            set(isPresented) {
+                when {
+                    isPresented ->
+                        if (applicationWindow != null) {
+                            this.gObject.present(applicationWindow)
+                        }
+                    this.gObject.canClose ->
+                        this.gObject.close()
+                    else ->
+                        this.gObject.forceClose()
+                }
+            }
+            set(onClose) { this.gObject.onClosed { onClose() } }
+            updater()
+        },
+        content = content,
+    )
+}
+
+@Composable
+fun Dialog(
+    modifier: Modifier = Modifier,
+    canClose: Boolean = true,
+    contentHeight: Int = 0,
+    contentWidth: Int = 0,
+    isPresented: Boolean,
+    followsContentSize: Boolean = false,
+    presentationMode: DialogPresentationMode = DialogPresentationMode.AUTO,
+    title: String?,
+    onClose: () -> Unit = {},
+    content: @Composable () -> Unit = {},
+) {
+    BaseDialog(
+        modifier = modifier,
+        title = title,
+        presentationMode = presentationMode,
+        canClose = canClose,
+        followsContentSize = followsContentSize,
+        contentWidth = contentWidth,
+        contentHeight = contentHeight,
+        isPresented = isPresented,
+        onClose = onClose,
+        content = content,
+        creator = {
+            SingleChildComposeNode(
+                Dialog.builder().build(),
+                set = { child = it },
+            )
+        },
+        updater = {},
+    )
+}
+
+@Composable
+fun AboutDialog(
+    modifier: Modifier = Modifier,
+    applicationIcon: String = "",
+    applicationName: String,
+    artists: Array<String> = emptyArray(),
+    canClose: Boolean = true,
+    comments: String = "",
+    contentHeight: Int = 0,
+    contentWidth: Int = 0,
+    copyright: String = "",
+    debugInfo: String = "",
+    debugInfoFilename: String = "",
+    designers: Array<String> = emptyArray(),
+    developerName: String = "",
+    developers: Array<String> = emptyArray(),
+    documenters: Array<String> = emptyArray(),
+    isPresented: Boolean,
+    issueUrl: String = "",
+    followsContentSize: Boolean = false,
+    license: String = "",
+    licenseType: License = License.UNKNOWN,
+    presentationMode: DialogPresentationMode = DialogPresentationMode.AUTO,
+    releaseNotes: String = "",
+    releaseNotesVersion: String = "",
+    supportUrl: String = "",
+    title: String?,
+    translatorCredits: String = "",
+    version: String = "",
+    website: String = "",
+    onClose: () -> Unit = {},
+    content: @Composable () -> Unit = {},
+) {
+    BaseDialog(
+        modifier = modifier,
+        canClose = canClose,
+        presentationMode = presentationMode,
+        title = title,
+        isPresented = isPresented,
+        contentWidth = contentWidth,
+        contentHeight = contentHeight,
+        followsContentSize = followsContentSize,
+        content = content,
+        onClose = onClose,
+        creator = {
+            SingleChildComposeNode(
+                AboutDialog.builder().build(),
+                set = { child = it },
+            )
+        },
+        updater = {
+            set(applicationIcon) { this.gObject.applicationIcon = applicationIcon }
+            set(applicationName) { this.gObject.applicationName = applicationName }
+            set(artists) { this.gObject.artists = artists }
+            set(comments) { this.gObject.comments = comments }
+            set(copyright) { this.gObject.copyright = copyright }
+            set(debugInfo) { this.gObject.debugInfo = debugInfo }
+            set(debugInfoFilename) { this.gObject.debugInfoFilename = debugInfoFilename }
+            set(designers) { this.gObject.designers = designers }
+            set(developerName) { this.gObject.developerName = developerName }
+            set(developers) { this.gObject.developers = developers }
+            set(documenters) { this.gObject.documenters = documenters }
+            set(issueUrl) { this.gObject.issueUrl = issueUrl }
+            set(license) { this.gObject.license = license }
+            set(licenseType) { this.gObject.licenseType = licenseType }
+            set(translatorCredits) { this.gObject.translatorCredits = translatorCredits }
+            set(releaseNotes) { this.gObject.releaseNotes = releaseNotes }
+            set(releaseNotesVersion) { this.gObject.releaseNotesVersion = releaseNotesVersion }
+            set(supportUrl) { this.gObject.supportUrl = supportUrl }
+            set(version) { this.gObject.version = version }
+            set(website) { this.gObject.website = website }
+        },
+    )
+}

--- a/src/main/kotlin/io/github/mmarco94/compose/gtk/components/FlowBox.kt
+++ b/src/main/kotlin/io/github/mmarco94/compose/gtk/components/FlowBox.kt
@@ -6,28 +6,36 @@ import io.github.mmarco94.compose.GtkApplier
 import io.github.mmarco94.compose.GtkComposeNode
 import io.github.mmarco94.compose.GtkContainerComposeNode
 import io.github.mmarco94.compose.modifier.Modifier
+import io.github.mmarco94.compose.requiresAddToParent
 import org.gnome.gobject.GObject
 import org.gnome.gtk.Adjustment
 import org.gnome.gtk.FlowBox
 import org.gnome.gtk.Orientation
 import org.gnome.gtk.Widget
 
-
 private class GtkFlowBoxComposeNode(gObject: FlowBox) : GtkContainerComposeNode<FlowBox, Widget>(gObject) {
     override fun add(index: Int, child: GtkComposeNode<GObject>) {
         val childWidget = child.gObject as Widget
-        gObject.insert(childWidget, index)
+        if (childWidget.requiresAddToParent) {
+            gObject.insert(childWidget, index)
+        }
         super.add(index, child)
     }
 
     override fun remove(index: Int) {
-        gObject.remove(children[index])
+        val childWidget = children[index]
+        if (childWidget.requiresAddToParent) {
+            gObject.remove(childWidget)
+        }
         super.remove(index)
     }
 
     override fun clear() {
         // TODO: use removeAll on GTK 4.12+
-        children.forEach { gObject.remove(it) }
+        children
+            .asSequence()
+            .filter { it.requiresAddToParent }
+            .forEach { gObject.remove(it) }
         super.clear()
     }
 }

--- a/src/main/kotlin/io/github/mmarco94/compose/gtk/components/ListBox.kt
+++ b/src/main/kotlin/io/github/mmarco94/compose/gtk/components/ListBox.kt
@@ -2,8 +2,8 @@ package io.github.mmarco94.compose.gtk.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ComposeNode
+import io.github.mmarco94.compose.*
 import io.github.mmarco94.compose.GtkApplier
-import io.github.mmarco94.compose.GtkComposeNode
 import io.github.mmarco94.compose.GtkContainerComposeNode
 import io.github.mmarco94.compose.SingleChildComposeNode
 import io.github.mmarco94.compose.VirtualComposeNode
@@ -18,18 +18,26 @@ import org.gnome.gtk.Widget
 private class GtkListBoxComposeNode(gObject: ListBox) : GtkContainerComposeNode<ListBox, Widget>(gObject) {
     override fun add(index: Int, child: GtkComposeNode<GObject>) {
         val childWidget = child.gObject as Widget
-        gObject.insert(childWidget, index)
+        if (childWidget.requiresAddToParent) {
+            gObject.insert(childWidget, index)
+        }
         super.add(index, child)
     }
 
     override fun remove(index: Int) {
-        gObject.remove(children[index])
+        val childWidget = children[index]
+        if (childWidget.requiresAddToParent) {
+            gObject.remove(childWidget)
+        }
         super.remove(index)
     }
 
     override fun clear() {
         // TODO adw 4.12 has removeAll
-        children.forEach { gObject.remove(it) }
+        children
+            .asSequence()
+            .filter { it.requiresAddToParent }
+            .forEach { gObject.remove(it) }
         super.clear()
     }
 }

--- a/src/test/kotlin/Dialogs.kt
+++ b/src/test/kotlin/Dialogs.kt
@@ -1,0 +1,89 @@
+import androidx.compose.runtime.*
+import io.github.mmarco94.compose.adw.application
+import io.github.mmarco94.compose.adw.components.AboutDialog
+import io.github.mmarco94.compose.adw.components.ApplicationWindow
+import io.github.mmarco94.compose.adw.components.Dialog
+import io.github.mmarco94.compose.adw.components.HeaderBar
+import io.github.mmarco94.compose.gtk.components.*
+import io.github.mmarco94.compose.modifier.*
+import org.gnome.adw.DialogPresentationMode
+import org.gnome.gtk.Align
+import org.gnome.gtk.License
+
+fun main(args: Array<String>) {
+    application("my.example.HelloApp", args) {
+        ApplicationWindow(
+            "Dialogs",
+            onClose = ::exitApplication,
+            defaultWidth = 960,
+            defaultHeight = 800,
+        ) {
+            var floatingDialog by remember { mutableStateOf(false) }
+            Dialog(
+                title = "Floating dialog",
+                isPresented = floatingDialog,
+                presentationMode = DialogPresentationMode.FLOATING,
+                onClose = { floatingDialog = false },
+            ) {
+                VerticalBox {
+                    HeaderBar()
+                    Label("Say something", modifier = Modifier.margin(64))
+                }
+            }
+
+            var bottomSheetDialog by remember { mutableStateOf(false) }
+            Dialog(
+                title = "Bottom sheet dialog",
+                isPresented = bottomSheetDialog,
+                presentationMode = DialogPresentationMode.BOTTOM_SHEET,
+                onClose = { bottomSheetDialog = false },
+            ) {
+                Label("Say something", modifier = Modifier.margin(64))
+            }
+
+            var aboutDialog by remember { mutableStateOf(false) }
+            AboutDialog(
+                applicationName = "Application",
+                applicationIcon = "help-about",
+                developerName = "Developer Name",
+                artists = arrayOf("Joe Dalton", "Jack Dalton", "William Dalton"),
+                designers = arrayOf("Jane Doe", "John Doe"),
+                licenseType = License.GPL_3_0,
+                issueUrl = "http://www.example.org",
+                releaseNotes = "<ul><li>first change</li><li>second change</li></ul>",
+                version = "1.2.3",
+                website = "http://www.example.org",
+                isPresented = aboutDialog,
+                title = "About",
+                contentWidth = 400,
+                contentHeight = 600,
+                onClose = { aboutDialog = false },
+            )
+
+            VerticalBox {
+                HeaderBar()
+
+                VerticalBox(
+                    modifier = Modifier.margin(16),
+                    spacing = 16,
+                ) {
+                    Button(
+                        modifier = Modifier.horizontalAlignment(Align.CENTER),
+                        label = "Floating dialog",
+                        onClick = { floatingDialog = true },
+                    )
+                    Button(
+                        modifier = Modifier.horizontalAlignment(Align.CENTER),
+                        label = "Bottom sheet dialog",
+                        onClick = { bottomSheetDialog = true },
+                    )
+                    Button(
+                        modifier = Modifier.horizontalAlignment(Align.CENTER),
+                        label = "About dialog",
+                        onClick = { aboutDialog = true },
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add a composable for [Adwaita Dialog](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.3/class.Dialog.html) component.

Notable / debatable points:
* I chose to convert present() / close() methods to a **stateful approach** with an **isPresented** state parameter. This allows a fully state based approach, which is simpler to use and less error prone.
* ~the dialog is currently **displayed in the current active window**. This might we what is wanted... or not. We *should* add a LocalApplicationWindow add present the Dialog on it, but there are some issues with the current compose node handling for this to work (I can explain if needed).~
* I had to modify the widget tree handling code a bit: Dialogs can't be added to a parent (this crashes the app) like other widgets, they just need to be created and presented to a window.
* also implemented `AboutDialog`, as it shares much code with Dialog

![Capture d’écran du 2025-04-13 12-52-50](https://github.com/user-attachments/assets/b84a1497-63cb-452a-94eb-b18ed19a2711)
![Capture d’écran du 2025-04-13 12-53-01](https://github.com/user-attachments/assets/7fe77348-6d21-44ea-b73d-56df3218cefd)
![Capture d’écran du 2025-04-13 16-56-41](https://github.com/user-attachments/assets/16236fbb-e4a4-444e-bde4-9c5f3496d7f7)
